### PR TITLE
[TICKET-35] feat: git PR 및 ISSUE 템플릿 설정

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,38 @@
+# Issue Title
+
+> FIXME: Describe the task in free format '<something task description>`
+
+<br>
+
+### 완료 조건
+
+- [ ] `<completion condition>`
+- [ ] `<completion condition>`
+
+<br> 
+
+## relate to issue
+> FIXME: fill  relate to issue  `<issue title>(#<issue number>)`
+
+<br>
+
+> #### Reference
+> FIXME: fill reference link
+> * `[title](link)`
+
+---
+
+<br>
+
+## Check List
+- [ ] issue 제목은 유의미한가?
+- [ ] issue 내용은 issue 내용만 확인하고도 모르는 사람도 파악할 수 있을 정도로 기술되었는가? (무엇을, 언제, 어디서...)
+- [ ] reference가 있다면 추가했는가?
+- [ ] 관련 issue가 있다면 추가했는가?
+- [ ] 유의미한 Label을 추가했는가?
+- [ ] Assginees를 추가했는가?
+- [ ] Estimate를 추가했는가?
+- [ ] 관련 Milestone이 있다면 추가했는가?
+- [ ] 관련 Epics가 있다면 추가했는가?
+
+---

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+# PR Title
+
+> FIXME: Describe the task in free format '<something task description>`
+
+<br>
+
+### 완료 조건
+
+- [ ] `<completion condition>`
+- [ ] `<completion condition>`
+
+<br> 
+
+## relate to PR
+> FIXME: fill  relate to issue  `<issue title>(#<issue number>)`
+
+<br>
+
+> #### Reference
+> FIXME: fill reference link
+> * `[title](link)`
+
+---
+
+<br>
+
+## Check List
+- [ ] PR 제목은 유의미한가?
+- [ ] PR 내용은 PR 내용만 확인하고도 모르는 사람도 파악할 수 있을 정도로 기술되었는가? (무엇을, 언제, 어디서...)
+- [ ] reference가 있다면 추가했는가?
+- [ ] 관련 issue가 있다면 추가했는가?
+- [ ] 유의미한 Label을 추가했는가?
+- [ ] Assginees를 추가했는가?
+- [ ] Estimate를 추가했는가?
+- [ ] 관련 Milestone이 있다면 추가했는가?
+- [ ] 관련 Epics가 있다면 추가했는가?
+
+---


### PR DESCRIPTION
# git PR 및 ISSUE 템플릿 설정

> 더욱 원활하고 깔끔한 PR, ISSUE 제기를 위해 템플릿을 설정한다.

<br>

### 완료 조건

- [x] `.github 폴더에 PR, ISSUE 관련 Template를 추가했는가`

<br> 

## relate to Issue
> TICKET-35

<br>

> #### Reference
> * [blog1](https://fernando.kr/develop/2019-05-29-github-pull-request-template-guide/)

---

<br>

## Check List
- [x] PR 제목은 유의미한가?
- [x] PR 내용은 PR 내용만 확인하고도 모르는 사람도 파악할 수 있을 정도로 기술되었는가? (무엇을, 언제, 어디서...)
- [x] reference가 있다면 추가했는가?
- [x] 관련 issue가 있다면 추가했는가?
- [x] 유의미한 Label을 추가했는가?
- [x] Assginees를 추가했는가?
- [ ] Estimate를 추가했는가?
- [ ] 관련 Milestone이 있다면 추가했는가?
- [ ] 관련 Epics가 있다면 추가했는가?

---
