### PR TITLE
[TICKET-46] fix: jasypt gradle build시 systemProperties 가져오도록 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ dependencyManagement {
 
 test {
     useJUnitPlatform()
+    systemProperty "jasypt.encryptor.password", System.getProperty("jasypt.encryptor.password")
 }
 
 // RestDocs Build시 Copy되도록 Task 추가 ==


### PR DESCRIPTION
# PR Title

> `Jasypt` grdle build시 jvm 옵션 가져오지 못하여 test 실패한 부분 수정

<br>

### 완료 조건

- [x] `./gradle build 시 PBEConfigError NPE 나지 않도록 수정`
<br> 

## relate to PR
> [TICKET-46](https://dolph.atlassian.net/jira/software/projects/TICKET/boards/3?selectedIssue=TICKET-46)

<br>

> #### Reference
> * [gradle build 변수 전달시 -d 옵션 세팅 방법](https://stackoverflow.com/questions/21406265/how-to-give-system-property-to-my-test-via-gradle-and-d)
> * [jasypt password 설정 방식 3가지](https://limitx.tistory.com/6)

---

build시 해당 값을 제대로 가져오지 못해 test쪽에 adapter 추가하였음

<br>

## Check List
- [x] PR 제목은 유의미한가?
- [x] PR 내용은 PR 내용만 확인하고도 모르는 사람도 파악할 수 있을 정도로 기술되었는가? (무엇을, 언제, 어디서...)
- [x] reference가 있다면 추가했는가?
- [x] 관련 issue가 있다면 추가했는가?
- [x] 유의미한 Label을 추가했는가?
- [x] Assginees를 추가했는가?
- [ ] Estimate를 추가했는가?
- [ ] 관련 Milestone이 있다면 추가했는가?
- [ ] 관련 Epics가 있다면 추가했는가?

---
