### PR TITLE
[TICKET-64] fix : spring datasource 변경 h2->PostgreSQL

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,14 @@
 spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: ENC(ahw18zDs3VK5yHnlD63tdEGLsuc+1nVGxgSPn/nAKVXPVqELBIlsmSPhhSzUpXg3TZAg13Ga3JOUerSfAqK4UQ==)
+    username: ENC(71M9V6VbtB6S0i/S/HcxPmy/TTiqAsrY)
+    password: ENC(zJWvcj62mjMzbiFJEacMGw==)
+    hikari:
+      schema: ticket
+
   profiles:
     active: local
-
-  datasource:
-    url: jdbc:h2:tcp://localhost/~/captain
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-
 
   jpa:
     hibernate:


### PR DESCRIPTION
## 설명

현재 h2로 지정되어있던 datasource를 저희가 실제로 사용할 PostgreSQL로 변경하였으며 jasypt 암호화를 시켜놓았습니다. 

### 작업 티켓 or 동기

TICKET-64

### 작업 내용

application.yml 부분의 datasource 속성을 수정했다.


## 체크리스트

- [ ] 무엇을 변경했는지 충분히 설명하고 있나요?
- [ ] 새로운 기술을 사용했다면, 그 기술을 설명하고 있나요?
- [ ] 이해하기 어려운 비즈니스 로직에 관해서 부연 설명을 하고 있나요?
- [ ] 팀원 두명을 Assign하고, Review Request에는 web-front 팀을 추가했나요?
- [ ] 작업을 설명하는 Jira 티켓을 추가했나요?
- [ ] 작업 범위에 대해서 테스트를 작성하셨나요?
- [ ] 인프라 작업, 릴리즈 PR이라면, Review Skip 레이블을 추가했나요?
```