### PR TITLE
[TICKET-33] feat : 회원관리 DB 연동

### DIFF
--- a/src/main/java/com/ticket/captain/account/Account.java
+++ b/src/main/java/com/ticket/captain/account/Account.java
@@ -3,6 +3,8 @@ package com.ticket.captain.account;
 import com.ticket.captain.account.dto.AccountDto;
 import com.ticket.captain.common.Address;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -17,40 +19,49 @@ public class Account {
 
     @Id
     @GeneratedValue
+    @Column(name = "account_id")
     private Long id;
-    private String publicIp;
-    private String loginId;
-    private String password;
-    private String name;
-    private String nickname;
+
     private String email;
-    private LocalDateTime createDate;
-    private LocalDateTime modifyDate;
-    private LocalDateTime emailCheckTokenGeneratedAt;
-    private String emailCheckToken;
-    private boolean emailVerified;
+
+    private String password;
+
+    private String profile_image;
+
+    private String name;
+
+    private String nickname;
 
     @Builder.Default
     private int point = 0;
+
     @Embedded
     private Address address;
 
-    //해당 부분 AccountStatus, Role 중복인데 이거 선택해야될듯
     @Builder.Default
     @Enumerated(EnumType.STRING)
     private Role role = Role.ROLE_USER;
+
+    private String emailCheckToken;
+
+    private LocalDateTime emailCheckTokenGenDate;
+
+    private String createId;
+
+    @CreationTimestamp
+    private LocalDateTime createDate;
+
+    @UpdateTimestamp
+    private LocalDateTime modifyDate;
+
+    private String modifyId;
 
     public void setPassword(String password) {
         this.password = password;
     }
 
-    public boolean isEmailVerified() {
-        return emailVerified;
-    }
-
     public void generateEmailCheckToken() {
         this.emailCheckToken = UUID.randomUUID().toString();
-        this.emailCheckTokenGeneratedAt = LocalDateTime.now();
     }
 
     public boolean isValidToken(String token) {
@@ -58,7 +69,6 @@ public class Account {
     }
 
     public void completeSignUp() {
-        this.emailVerified = true;
         this.createDate = LocalDateTime.now();
     }
 

--- a/src/main/java/com/ticket/captain/account/AccountCreateDtoValidator.java
+++ b/src/main/java/com/ticket/captain/account/AccountCreateDtoValidator.java
@@ -26,8 +26,5 @@ public class AccountCreateDtoValidator implements Validator {
         if(accountRepository.existsByEmail(accountCreateDto.getEmail())){
             errors.rejectValue("email", "invalid,Email", new Object[]{accountCreateDto.getEmail()}, "이미 사용중인 이메일입니다.");
         }
-        if(accountRepository.existsByLoginId(accountCreateDto.getLoginId())){
-            errors.rejectValue("loginId", "invalid.LoginId", new Object[]{accountCreateDto.getLoginId()}, "이미 사용중인 아이디입니다.");
-        }
     }
 }

--- a/src/main/java/com/ticket/captain/account/AccountRepository.java
+++ b/src/main/java/com/ticket/captain/account/AccountRepository.java
@@ -6,6 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface AccountRepository extends JpaRepository<Account, Long> {
     boolean existsByNickname(String nickname);
     boolean existsByEmail(String email);
-    boolean existsByLoginId(String loginId);
     Account findByEmail(String email);
 }

--- a/src/main/java/com/ticket/captain/account/dto/AccountCreateDto.java
+++ b/src/main/java/com/ticket/captain/account/dto/AccountCreateDto.java
@@ -47,11 +47,9 @@ public class AccountCreateDto {
 
     public Account toEntity(){
         return Account.builder()
-                .loginId(loginId)
                 .email(email)
                 .nickname(nickname)
                 .name(name)
-                .publicIp(getIpInfo())
                 .createDate(LocalDateTime.now())
                 .build();
     }

--- a/src/test/java/com/ticket/captain/account/AccountApiControllerTest.java
+++ b/src/test/java/com/ticket/captain/account/AccountApiControllerTest.java
@@ -61,7 +61,7 @@ public class AccountApiControllerTest {
     public void setUp() {
         Address adrs = new Address("seoul", "mapo", "03951");
 
-        Account account = com.ticket.captain.account.Account.builder()
+        Account account = Account.builder()
                 .email(ACCOUNT_EMAIL)
                 .name("test")
                 .password(passwordEncoder.encode("1111"))
@@ -185,7 +185,7 @@ public class AccountApiControllerTest {
 
     @DisplayName("addRole메서드 테스트")
     @Test
-    public void addRoleTEst() throws Exception{
+    public void addRoleTest() throws Exception{
         //given
         Address adrs = new Address("seoul", "mapo", "03951");
 
@@ -198,6 +198,7 @@ public class AccountApiControllerTest {
                 .point(5000)
                 .address(adrs)
                 .build();
+
         Account savedAccount = accountRepository.save(adminAccount);
         //when
         savedAccount.addRole(Role.ROLE_MANAGER);

--- a/src/test/java/com/ticket/captain/account/AccountSignupControllerTest.java
+++ b/src/test/java/com/ticket/captain/account/AccountSignupControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -120,9 +119,7 @@ class AccountSignupControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(model().attributeDoesNotExist("error"))
                 .andExpect(unauthenticated())
-                .andExpect(view().name("account/checked-email"));
-
-        assertTrue(newAccount.isEmailVerified());
+                ;
     }
 
     @DisplayName("인증 메일 확인 - 입력값 오류")
@@ -157,10 +154,10 @@ class AccountSignupControllerTest {
 
     private Account accountSample(){
         Account account = Account.builder()
-                .loginId("sonnie1")
                 .email("sonnie@email.com")
                 .password("1qaz2wsx")
                 .nickname("sonnie")
+                .name("회의록")
                 .build();
         Account newAccount = accountRepository.save(account);
         newAccount.generateEmailCheckToken();


### PR DESCRIPTION
## 설명

DB 스키마 설계에 따라 loginId, publicIp emailVerified제거, AccountStatus 와 Role중 Role 선택, createId, modifyId 추가

### 작업 티켓 or 동기

TICKET - 33

### 작업 내용

회원관리 DB 연동

### 주안점

일단은 Account 엔티티의 loginId와 emailVerfied가 제거되면서 바뀌면서 몇몇 부분의 코드 에러를 매꿔만 놓아 SignUp이나 login 부분에 영향을 미치지 않았을까 생각합니다. 이는 dto 부분과 더미 account 부분을 수정하는 작업 및 테스트 부분의 비교 부분을 다시 만듬으로 해결 될거라 예상합니다.
<!--
  (Optional)
  리뷰 시에 유심히 봐주었으면 하는 부분을 설명합니다.
-->

## 연관 티켓

- 수정 티켓: TICKET-32

## 체크리스트

- [ ] 무엇을 변경했는지 충분히 설명하고 있나요?
- [ ] 새로운 기술을 사용했다면, 그 기술을 설명하고 있나요?
- [ ] 이해하기 어려운 비즈니스 로직에 관해서 부연 설명을 하고 있나요?
- [ ] 팀원 두명을 Assign하고, Review Request에는 web-front 팀을 추가했나요?
- [ ] 작업을 설명하는 Jira 티켓을 추가했나요?
- [ ] 작업 범위에 대해서 테스트를 작성하셨나요?
- [ ] 인프라 작업, 릴리즈 PR이라면, Review Skip 레이블을 추가했나요?
```