### PR TITLE
[TICKET-81] refactor: Order Entity 수정 및 TicketTest 변경

### DIFF
--- a/src/main/java/com/ticket/captain/account/Account.java
+++ b/src/main/java/com/ticket/captain/account/Account.java
@@ -2,12 +2,15 @@ package com.ticket.captain.account;
 
 import com.ticket.captain.account.dto.AccountDto;
 import com.ticket.captain.common.Address;
+import com.ticket.captain.order.Order;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -21,6 +24,9 @@ public class Account {
     @GeneratedValue
     @Column(name = "account_id")
     private Long id;
+
+    @OneToMany(mappedBy = "account")
+    private List<Order> orders = new ArrayList<>();
 
     private String email;
 

--- a/src/main/java/com/ticket/captain/festivalDetail/FestivalDetail.java
+++ b/src/main/java/com/ticket/captain/festivalDetail/FestivalDetail.java
@@ -1,6 +1,7 @@
 package com.ticket.captain.festivalDetail;
 
 import com.ticket.captain.festival.Festival;
+import com.ticket.captain.order.Order;
 import com.ticket.captain.salesType.SalesType;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,6 +9,8 @@ import lombok.ToString;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Builder
 @Entity(name = "festival_detail")
@@ -19,6 +22,9 @@ public class FestivalDetail {
     @GeneratedValue
     @Column(name = "festival_sq")
     private Long id;
+
+    @OneToMany(mappedBy = "festivalDetail")
+    private List<Order> orders = new ArrayList<>();
 
     @Column(name = "perform_datetime")
     private LocalDateTime processDate;

--- a/src/main/java/com/ticket/captain/festivalDetail/FestivalDetail.java
+++ b/src/main/java/com/ticket/captain/festivalDetail/FestivalDetail.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-@Builder
 @Entity(name = "festival_detail")
 @Getter
 @ToString
@@ -61,7 +60,7 @@ public class FestivalDetail {
     public FestivalDetail() {
 
     }
-
+    @Builder
     public FestivalDetail(Long id, LocalDateTime processDate, Long amount, Long price, LocalDateTime drawDate, LocalDateTime createDate, Long createId, LocalDateTime modifyDate, Long modifyId, Festival festival, SalesType salesType) {
         this.id = id;
         this.processDate = processDate;

--- a/src/main/java/com/ticket/captain/order/Order.java
+++ b/src/main/java/com/ticket/captain/order/Order.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "OrderTable")
 public class Order {
 
     @Id @GeneratedValue

--- a/src/main/java/com/ticket/captain/order/Order.java
+++ b/src/main/java/com/ticket/captain/order/Order.java
@@ -1,0 +1,35 @@
+package com.ticket.captain.order;
+
+import com.ticket.captain.account.Account;
+import com.ticket.captain.festivalDetail.FestivalDetail;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+public class Order {
+
+    @Id @GeneratedValue
+    @Column(name = "order_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "festival_sq")
+    private FestivalDetail festivalDetail;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account")
+    private Account account;
+
+    @Enumerated(EnumType.STRING)
+    private StatusCode statusCode;
+
+    private LocalDateTime purchaseDate;
+
+    private int totalAmount;
+
+    private int usePointAmount;
+
+    private int discountRate;
+
+}

--- a/src/main/java/com/ticket/captain/order/Order.java
+++ b/src/main/java/com/ticket/captain/order/Order.java
@@ -3,6 +3,8 @@ package com.ticket.captain.order;
 import com.ticket.captain.account.Account;
 import com.ticket.captain.festivalDetail.FestivalDetail;
 import com.ticket.captain.ticket.Ticket;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 
 import javax.persistence.*;
@@ -11,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order {
 
     @Id @GeneratedValue

--- a/src/main/java/com/ticket/captain/order/Order.java
+++ b/src/main/java/com/ticket/captain/order/Order.java
@@ -2,34 +2,48 @@ package com.ticket.captain.order;
 
 import com.ticket.captain.account.Account;
 import com.ticket.captain.festivalDetail.FestivalDetail;
+import com.ticket.captain.ticket.Ticket;
+import org.springframework.data.annotation.CreatedDate;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 public class Order {
 
     @Id @GeneratedValue
-    @Column(name = "order_id")
+    @Column(name = "order_no")  //erdcloud 에 order_no 라고 돼있어서 일단 이렇게 했습니다.
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "festival_sq")
     private FestivalDetail festivalDetail;
 
+    //festivalDetail 를 통해서 festivalId 받아서 필드 값으로 집어넣어 주어야 한다.
+    private Long festivalId;
+
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "account")
+    @JoinColumn(name = "account_id")
     private Account account;
+
+    @OneToMany(mappedBy = "order")
+    private List<Ticket> tickets = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     private StatusCode statusCode;
 
+    @CreatedDate
     private LocalDateTime purchaseDate;
 
     private int totalAmount;
 
     private int usePointAmount;
 
-    private int discountRate;
+    /**
+     * 할인 관한 interface 추가가 되어야함
+     */
+    //private Discount discountRate
 
 }

--- a/src/main/java/com/ticket/captain/order/StatusCode.java
+++ b/src/main/java/com/ticket/captain/order/StatusCode.java
@@ -1,0 +1,10 @@
+package com.ticket.captain.order;
+
+public enum StatusCode {
+    PURCHASE("결제"),READY("배송준비중"), SHIPPING("배송중"), DELIVERED("배송완료"), PARTLY_CANCELD("부분취소"),
+    CANCELED("취소"), REFUND("반품");
+    String code;
+    StatusCode(String code){
+        this.code = code;
+    };
+}

--- a/src/main/java/com/ticket/captain/ticket/Ticket.java
+++ b/src/main/java/com/ticket/captain/ticket/Ticket.java
@@ -24,9 +24,6 @@ public class Ticket {
     private String ticketNo;
 
     @Column(nullable = false)
-    private String orderNo;
-
-    @Column(nullable = false)
     private Long festivalId;
 
     @Column(nullable = false)
@@ -39,11 +36,10 @@ public class Ticket {
     private Long price;
 
     @Builder
-    private Ticket(Long ticketId, String ticketNo, String orderNo, Long festivalId, Long festivalSq, Long statusCode, Long price) {
+    private Ticket(Long ticketId, String ticketNo, Long festivalId, Long festivalSq, Long statusCode, Long price) {
 
         this.ticketId = ticketId;
         this.ticketNo = ticketNo;
-        this.orderNo = orderNo;
         this.festivalId = festivalId;
         this.festivalSq = festivalSq;
         this.statusCode = statusCode;

--- a/src/main/java/com/ticket/captain/ticket/Ticket.java
+++ b/src/main/java/com/ticket/captain/ticket/Ticket.java
@@ -1,14 +1,12 @@
 package com.ticket.captain.ticket;
 
+import com.ticket.captain.order.Order;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
 @Getter
@@ -17,6 +15,10 @@ public class Ticket {
     @Id
     @GeneratedValue
     private Long ticketId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_no")
+    private Order order;
 
     @Column(nullable = false)
     private String ticketNo;

--- a/src/main/java/com/ticket/captain/ticket/dto/TicketCreateDto.java
+++ b/src/main/java/com/ticket/captain/ticket/dto/TicketCreateDto.java
@@ -8,16 +8,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TicketCreateDto {
     private String ticketNo;
-    private String orderNo;
     private Long festivalId;
     private Long festivalSq;
     private Long statusCode;
     private Long price;
 
     @Builder
-    private TicketCreateDto(String ticketNo, String orderNo, Long festivalId, Long festivalSq, Long statusCode, Long price) {
+    private TicketCreateDto(String ticketNo, Long festivalId, Long festivalSq, Long statusCode, Long price) {
         this.ticketNo = ticketNo;
-        this.orderNo = orderNo;
         this.festivalId = festivalId;
         this.festivalSq = festivalSq;
         this.statusCode = statusCode;
@@ -27,7 +25,6 @@ public class TicketCreateDto {
     public TicketCreateDto toDto() {
         return TicketCreateDto.builder()
                 .ticketNo(ticketNo)
-                .orderNo(orderNo)
                 .festivalId(festivalId)
                 .festivalSq(festivalSq)
                 .statusCode(statusCode)
@@ -38,7 +35,6 @@ public class TicketCreateDto {
     public Ticket toEntity() {
         return Ticket.builder()
                 .ticketNo(ticketNo)
-                .orderNo(orderNo)
                 .festivalId(festivalId)
                 .festivalSq(festivalSq)
                 .statusCode(statusCode)

--- a/src/main/java/com/ticket/captain/ticket/dto/TicketDto.java
+++ b/src/main/java/com/ticket/captain/ticket/dto/TicketDto.java
@@ -11,17 +11,15 @@ import lombok.NoArgsConstructor;
 public class TicketDto {
     private Long ticketId;
     private String ticketNo;
-    private String orderNo;
     private Long festivalId;
     private Long festivalSq;
     private Long statusCode;
     private Long price;
 
     @Builder
-    private TicketDto(Long ticketId, String ticketNo, String orderNo, Long festivalId, Long festivalSq, Long statusCode, Long price) {
+    private TicketDto(Long ticketId, String ticketNo, Long festivalId, Long festivalSq, Long statusCode, Long price) {
         this.ticketId = ticketId;
         this.ticketNo = ticketNo;
-        this.orderNo = orderNo;
         this.festivalId = festivalId;
         this.festivalSq = festivalSq;
         this.statusCode = statusCode;
@@ -32,7 +30,6 @@ public class TicketDto {
         return TicketDto.builder()
                 .ticketId(ticket.getTicketId())
                 .ticketNo(ticket.getTicketNo())
-                .orderNo(ticket.getOrderNo())
                 .festivalId(ticket.getFestivalId())
                 .festivalSq(ticket.getFestivalSq())
                 .statusCode(ticket.getStatusCode())

--- a/src/test/java/com/ticket/captain/ticket/TicketCreateDocumentationTests.java
+++ b/src/test/java/com/ticket/captain/ticket/TicketCreateDocumentationTests.java
@@ -34,7 +34,6 @@ public class TicketCreateDocumentationTests extends ApiDocumentationTest {
                 .willReturn(TicketDto.builder()
                         .ticketId(2L)
                         .ticketNo("IU00000002")
-                        .orderNo("20110100000000002")
                         .festivalId(1L)
                         .festivalSq(1L)
                         .statusCode(2L)
@@ -43,7 +42,6 @@ public class TicketCreateDocumentationTests extends ApiDocumentationTest {
 
         Request request = new Request();
         request.ticketNo = "IU00000002";
-        request.orderNo = "20110100000000002";
         request.festivalId = "1";
         request.festivalSq = "1";
         request.statusCode = "2";
@@ -63,7 +61,6 @@ public class TicketCreateDocumentationTests extends ApiDocumentationTest {
                         getDocumentResponse(),
                         requestFields(
                                 fieldWithPath("ticketNo").type(JsonFieldType.STRING).description("티켓번호"),
-                                fieldWithPath("orderNo").type(JsonFieldType.STRING).description("주문번호"),
                                 fieldWithPath("festivalId").type(JsonFieldType.STRING).description("축제 ID"),
                                 fieldWithPath("festivalSq").type(JsonFieldType.STRING).description("축제 순번"),
                                 fieldWithPath("statusCode").type(JsonFieldType.STRING).description("주문상태코드"),
@@ -72,7 +69,6 @@ public class TicketCreateDocumentationTests extends ApiDocumentationTest {
                         responseFields(beneathPath("data").withSubsectionId("data"),
                                 fieldWithPath("ticketId").type(JsonFieldType.NUMBER).description("티켓 ID"),
                                 fieldWithPath("ticketNo").type(JsonFieldType.STRING).description("티켓번호"),
-                                fieldWithPath("orderNo").type(JsonFieldType.STRING).description("주문번호"),
                                 fieldWithPath("festivalId").type(JsonFieldType.NUMBER).description("축제 ID"),
                                 fieldWithPath("festivalSq").type(JsonFieldType.NUMBER).description("축제 순번"),
                                 fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("주문상태코드"),
@@ -86,7 +82,6 @@ public class TicketCreateDocumentationTests extends ApiDocumentationTest {
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Request {
         String ticketNo;
-        String orderNo;
         String festivalId;
         String festivalSq;
         String statusCode;

--- a/src/test/java/com/ticket/captain/ticket/TicketListDocumentationTests.java
+++ b/src/test/java/com/ticket/captain/ticket/TicketListDocumentationTests.java
@@ -37,7 +37,6 @@ public class TicketListDocumentationTests extends ApiDocumentationTest {
                 .willReturn(TicketDto.builder()
                         .ticketId(1L)
                         .ticketNo("IU00000001")
-                        .orderNo("20110100000000001")
                         .festivalId(1L)
                         .festivalSq(1L)
                         .statusCode(2L)
@@ -59,7 +58,6 @@ public class TicketListDocumentationTests extends ApiDocumentationTest {
                         responseFields(beneathPath("data").withSubsectionId("data"),
                                 fieldWithPath("ticketId").type(JsonFieldType.NUMBER).description("티켓 ID"),
                                 fieldWithPath("ticketNo").type(JsonFieldType.STRING).description("티켓번호"),
-                                fieldWithPath("orderNo").type(JsonFieldType.STRING).description("주문번호"),
                                 fieldWithPath("festivalId").type(JsonFieldType.NUMBER).description("축제 ID"),
                                 fieldWithPath("festivalSq").type(JsonFieldType.NUMBER).description("축제 순번"),
                                 fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("주문상태코드"),
@@ -77,7 +75,6 @@ public class TicketListDocumentationTests extends ApiDocumentationTest {
                 TicketDto.builder()
                         .ticketId(1L)
                         .ticketNo("IU00000001")
-                        .orderNo("20110100000000001")
                         .festivalId(1L)
                         .festivalSq(1L)
                         .statusCode(2L)
@@ -100,7 +97,6 @@ public class TicketListDocumentationTests extends ApiDocumentationTest {
                         responseFields(beneathPath("data[]").withSubsectionId("data"),
                                 fieldWithPath("ticketId").type(JsonFieldType.NUMBER).description("티켓 ID"),
                                 fieldWithPath("ticketNo").type(JsonFieldType.STRING).description("티켓번호"),
-                                fieldWithPath("orderNo").type(JsonFieldType.STRING).description("주문번호"),
                                 fieldWithPath("festivalId").type(JsonFieldType.NUMBER).description("축제 ID"),
                                 fieldWithPath("festivalSq").type(JsonFieldType.NUMBER).description("축제 순번"),
                                 fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("주문상태코드"),


### PR DESCRIPTION
# [TICKET-81] refactor: Order Entity 수정 및 TicketTest 변경
=======
<br>

### 완료 조건

- [x] `Order Entity 수정`
- [x] `Ticket Test 변경`

<br> 

### 주안점

TICKET-74 에서는 Order Entity를 추가했었습니다.  
하지만 추가만 하고 그대로 올려서 생긴 오류들을 TICKET-81 에서 해결했습니다.  
Order는 DB 예약어 이기 때문에 테이블명으로 사용이 불가능 해서 생기는 오류가 있어 Table(name = "OrderTable")로 설정해줬습니다.  

Ticket Entity와 Order Entity 가 다대일 관계를 가져서 기존의 Ticket Entity 내부의 ``String orderNo``를 삭제하고 매핑작업을 해주었습니다. 이 변경과 함께, TicketCreateDto, TicketDto 내부의 orderNo 관련을 모두 삭제했습니다. Ticket 과 관련된 test 내에서의 orderNo 코드들도 모두 삭제해주었습니다.  

FestivalDetail  클래스도 Order Entity와 매핑을 시켜주었는데 기존의 orderNo를 삭제하면서 생성자 내부의 orderNo도 삭제했습니다. ``@Builder``가 클래스 상위에 붙어있었는데 이는 ``AllArgsConstructor`` 의 역할을 하게되어서 문제가 생기니 생성자 위로 옮겨 주었습니다. 이 부분 때문에 현성님이 올리실 FestivalDetail과 사소한 conflict이 날 것 같습니다. 해당 클래스에 date 관련은 따로 어노테이션으로 처리해주어야 될 것이고, 생성자 파라미터에서도 date관련 필드와 pk 관련 필드가 빠져야 되는데 이 부분은 건들지 않았습니다.
<br>

## 연관 티켓

TICKET-74 와 이어지는 브랜치라고 생각하시면 되겠습니다.  

<br>

## 체크리스트

- [x] PR 제목은 유의미한가요?
- [x] 무엇을 변경했는지 충분히 설명하고 있나요?
- [ ] reference가 있다면 추가했나요?
- [x] 작업을 설명하는 Jira 티켓을 추가했나요?
- [x] 작업 범위에 대해서 테스트를 작성하셨나요?
- [x] 팀원 두명을 Assign하고, Review Request에는 모든 팀원을 추가했나요?
- [ ] 새로운 기술을 사용했다면, 그 기술을 설명하고 있나요?
- [ ] 이해하기 어려운 비즈니스 로직에 관해서 부연 설명을 하고 있나요?
- [ ] 인프라 작업, 릴리즈 PR이라면, Review Skip 레이블을 추가했나요?
=======

[TICKET-81]: https://dolph.atlassian.net/browse/TICKET-81