### PR TITLE
[TICKET-84] fix : Account Rest Docs 오류 수정

### DIFF
--- a/src/main/java/com/ticket/captain/account/AccountResource.java
+++ b/src/main/java/com/ticket/captain/account/AccountResource.java
@@ -1,0 +1,21 @@
+package com.ticket.captain.account;
+
+import com.ticket.captain.account.dto.AccountDto;
+import com.ticket.captain.account.dto.AccountPutDto;
+import com.ticket.captain.account.dto.AccountRoleDto;
+import org.springframework.hateoas.EntityModel;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+
+public class AccountResource extends EntityModel<AccountDto> {
+
+    public static EntityModel<AccountDto> of(AccountDto accountDto){
+        return EntityModel.of(accountDto).add(linkTo(AccountApiController.class).slash(accountDto.getId()).withSelfRel());
+    }
+    public static EntityModel<AccountPutDto> of(AccountPutDto accountPutDto){
+        return EntityModel.of(accountPutDto).add(linkTo(AccountApiController.class).slash(accountPutDto.getId()).withSelfRel());
+    }
+    public static EntityModel<AccountRoleDto> of(AccountRoleDto accountRoleDto){
+        return EntityModel.of(accountRoleDto).add(linkTo(AccountApiController.class).slash(accountRoleDto.getId()).withSelfRel());
+    }
+}


### PR DESCRIPTION
### 완료 조건

- [ ] `AccountResource 추가`
- [ ] `회원 목록, 회원 상세조회`

<br> 

### 주안점

AccountResource 부분을 build 안의 java 파일을 import해서 올라가지 않아서 오류가 났습니다 그래서 다시 main 안에 생성했고
restdocs 안올라온 부분 추가했습니다~
<br>

## 연관 PR

#47 [TICKET-69] feat : 회원관리 부분 restdocs TestDocument 작성

<br>

## 연관 티켓

TICKET-69

<br>


[TICKET-69]: https://dolph.atlassian.net/browse/TICKET-69