### PR TITLE
[TICKET-86] fix: ticket 테이블 컬럼 변경으로 인한 도메인 수정

### DIFF
--- a/src/main/java/com/ticket/captain/ticket/Ticket.java
+++ b/src/main/java/com/ticket/captain/ticket/Ticket.java
@@ -1,5 +1,6 @@
 package com.ticket.captain.ticket;
 
+import com.ticket.captain.festivalDetail.FestivalDetail;
 import com.ticket.captain.order.Order;
 import com.ticket.captain.order.StatusCode;
 import lombok.AccessLevel;
@@ -18,8 +19,12 @@ public class Ticket {
     private Long ticketId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "order_no")
+    @JoinColumn(name = "order_id")
     private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "festival_detail_id")
+    private FestivalDetail festivalDetail;
 
     @Column(nullable = false)
     private String ticketNo;
@@ -36,8 +41,8 @@ public class Ticket {
         this.price = price;
     }
 
-    public void update(String statusCode) {
-        this.statusCode = statusCode;
+    public void update(StatusCode statusCode) {
+        this.statusCode = statusCode.name();
     }
 
     public void orderSetting(Order order) {

--- a/src/main/java/com/ticket/captain/ticket/dto/TicketCreateDto.java
+++ b/src/main/java/com/ticket/captain/ticket/dto/TicketCreateDto.java
@@ -9,16 +9,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TicketCreateDto {
     private String ticketNo;
-    private Long festivalId;
-    private Long festivalSq;
+    private Long festivalDetailId;
     private StatusCode statusCode;
     private Long price;
 
     @Builder
-    private TicketCreateDto(String ticketNo, Long festivalId, Long festivalSq, StatusCode statusCode, Long price) {
+    private TicketCreateDto(String ticketNo, Long festivalDetailId, StatusCode statusCode, Long price) {
         this.ticketNo = ticketNo;
-        this.festivalId = festivalId;
-        this.festivalSq = festivalSq;
+        this.festivalDetailId = festivalDetailId;
         this.statusCode = statusCode;
         this.price = price;
     }
@@ -26,8 +24,7 @@ public class TicketCreateDto {
     public TicketCreateDto toDto() {
         return TicketCreateDto.builder()
                 .ticketNo(ticketNo)
-                .festivalId(festivalId)
-                .festivalSq(festivalSq)
+                .festivalDetailId(festivalDetailId)
                 .statusCode(statusCode)
                 .price(price)
                 .build();
@@ -36,9 +33,8 @@ public class TicketCreateDto {
     public Ticket toEntity() {
         return Ticket.builder()
                 .ticketNo(ticketNo)
-                .festivalId(festivalId)
-                .festivalSq(festivalSq)
-                .statusCode(statusCode)
+//                .festivalDetail()
+                .statusCode(statusCode.name())
                 .price(price)
                 .build();
     }

--- a/src/main/java/com/ticket/captain/ticket/dto/TicketDto.java
+++ b/src/main/java/com/ticket/captain/ticket/dto/TicketDto.java
@@ -1,6 +1,5 @@
 package com.ticket.captain.ticket.dto;
 
-import com.ticket.captain.order.StatusCode;
 import com.ticket.captain.ticket.Ticket;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,17 +11,15 @@ import lombok.NoArgsConstructor;
 public class TicketDto {
     private Long ticketId;
     private String ticketNo;
-    private Long festivalId;
-    private Long festivalSq;
+    private Long festivalDetailId;
     private String statusCode;
     private Long price;
 
     @Builder
-    private TicketDto(Long ticketId, String ticketNo, Long festivalId, Long festivalSq, String statusCode, Long price) {
+    private TicketDto(Long ticketId, String ticketNo, Long festivalDetailId, Long festivalSq, String statusCode, Long price) {
         this.ticketId = ticketId;
         this.ticketNo = ticketNo;
-        this.festivalId = festivalId;
-        this.festivalSq = festivalSq;
+        this.festivalDetailId = festivalDetailId;
         this.statusCode = statusCode;
         this.price = price;
     }
@@ -31,6 +28,7 @@ public class TicketDto {
         return TicketDto.builder()
                 .ticketId(ticket.getTicketId())
                 .ticketNo(ticket.getTicketNo())
+                .festivalDetailId(ticket.getFestivalDetail().getId())
                 .statusCode(ticket.getStatusCode())
                 .price(ticket.getPrice())
                 .build();

--- a/src/main/java/com/ticket/captain/ticket/dto/TicketUpdateDto.java
+++ b/src/main/java/com/ticket/captain/ticket/dto/TicketUpdateDto.java
@@ -8,20 +8,20 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class TicketUpdateDto {
-    private StatusCode stateCode;
+    private StatusCode statusCode;
 
     @Builder
-    private TicketUpdateDto(StatusCode stateCode) {
-        this.stateCode = stateCode;
+    private TicketUpdateDto(StatusCode statusCode) {
+        this.statusCode = statusCode;
     }
 
     public TicketUpdateDto toDto() {
         return TicketUpdateDto.builder()
-                .stateCode(stateCode)
+                .statusCode(statusCode)
                 .build();
     }
 
     public void apply(Ticket ticket) {
-        ticket.update(stateCode);
+        ticket.update(statusCode);
     }
 }


### PR DESCRIPTION
# [TICKET-86] fix: ticket 테이블 컬럼 변경으로 인한 도메인 수정

<br>

### 완료 조건

- [x] `festivalDetail 엔티티 추가`
- [x] `Dto 내에서 festivalId, festivalSq 제거`

<br> 

### 주안점

현재 TicketCreateDto에서 festivalDetail 부분을 생성하는 부분은 임시로 주석처리해두었습니다.
(차후 order쪽 로직 변경시 추가할것)

<br>

## 연관 PR



<br>

## 연관 티켓


<br>

#### 레퍼런스

---

<br>

## 체크리스트

- [x] PR 제목은 유의미한가요?
- [x] 무엇을 변경했는지 충분히 설명하고 있나요?
- [ ] reference가 있다면 추가했나요?
- [x] 작업을 설명하는 Jira 티켓을 추가했나요?
- [ ] 작업 범위에 대해서 테스트를 작성하셨나요?
- [x] 팀원 두명을 Assign하고, Review Request에는 모든 팀원을 추가했나요?
- [ ] 새로운 기술을 사용했다면, 그 기술을 설명하고 있나요?
- [ ] 이해하기 어려운 비즈니스 로직에 관해서 부연 설명을 하고 있나요?
- [ ] 인프라 작업, 릴리즈 PR이라면, Review Skip 레이블을 추가했나요?

---


[TICKET-86]: https://dolph.atlassian.net/browse/TICKET-86