### PR TITLE
[TICKET-91] refactor : 회원정보를 Account 파라미터로 받아오기 위한 리팩토링

### DIFF
--- a/src/main/java/com/ticket/captain/account/AccountService.java
+++ b/src/main/java/com/ticket/captain/account/AccountService.java
@@ -10,8 +10,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -20,8 +18,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
-
-import java.util.List;
 
 @Service
 @Slf4j
@@ -67,12 +63,12 @@ public class AccountService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 
-            Account account = accountRepository.findByEmail(email);
+        Account account = accountRepository.findByEmail(email);
 
         if (account == null) {
             throw new UsernameNotFoundException(email);
         }
-        return new User(account.getEmail(), account.getPassword(), List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        return new UserAccount(account);
     }
 
     public Page<AccountDto> findAccountList(Pageable pageable) {

--- a/src/main/java/com/ticket/captain/account/UserAccount.java
+++ b/src/main/java/com/ticket/captain/account/UserAccount.java
@@ -1,0 +1,18 @@
+package com.ticket.captain.account;
+
+import lombok.Getter;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.List;
+
+@Getter
+public class UserAccount extends User {
+
+    public Account account;
+
+    public UserAccount(Account account) {
+        super(account.getEmail(), account.getPassword(), List.of(new SimpleGrantedAuthority("ROLE_USER")));
+        this.account = account;
+    }
+}

--- a/src/test/java/com/ticket/captain/account/WithAccount.java
+++ b/src/test/java/com/ticket/captain/account/WithAccount.java
@@ -1,0 +1,14 @@
+package com.ticket.captain.account;
+
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithAccountSecurityContextFactory.class)
+public @interface WithAccount {
+
+    String value();
+}

--- a/src/test/java/com/ticket/captain/account/WithAccountSecurityContextFactory.java
+++ b/src/test/java/com/ticket/captain/account/WithAccountSecurityContextFactory.java
@@ -1,0 +1,37 @@
+package com.ticket.captain.account;
+
+import com.ticket.captain.account.dto.AccountCreateDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+@RequiredArgsConstructor
+public class WithAccountSecurityContextFactory implements WithSecurityContextFactory<WithAccount> {
+
+    private final AccountService accountService;
+
+    @Override
+    public SecurityContext createSecurityContext(WithAccount withAccount) {
+
+        String nickname = withAccount.value();
+
+        AccountCreateDto accountCreateDto = AccountCreateDto.builder()
+                .email("eunseong@naver.com")
+                .password("1q2w3e4r")
+                .nickname("dmstjd1024")
+                .name("eunseong")
+                .build();
+        accountService.createAccount(accountCreateDto);
+
+        UserDetails principal = accountService.loadUserByUsername(nickname);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, principal.getPassword(), principal.getAuthorities());
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+
+        return context;
+    }
+}


### PR DESCRIPTION
### 완료 조건

- [ ] `Controller에 파라미터로 현재 계정의 Account를 사용하기 위한 작업 `
- [ ] `test쪽에 MockUser가 아닌 가상의 Account를 생성해 로그인까지 시켜주는 WithAccount 어노테이션을 생성`

<br> 

### 주안점

new User(account.getEmail(), account.getPassword(), List.of(new SimpleGrantedAuthority("ROLE_USER")));
        return new UserAccount(account);
'''

AccountService에서 loadByUsername 이 부분에 리턴 값을 new User가 아닌 account를 추가로 넣어주는 UserAccount로 변경했습니다 이외에는 별다른 주안점은 없는 것 같습니다! 인프런 강의 보고 이 프로젝트에도 반영하고 싶어서 집어넣었습니다~

[스프링과 JPA 기반 웹 애플리케이션 개발](https://www.inflearn.com/course/%EC%8A%A4%ED%94%84%EB%A7%81-JPA-%EC%9B%B9%EC%95%B1/dashboard)