### PR TITLE
[TICKET-94] statusCode DB 'status_id'와 매핑하도록 @Column 추가

### DIFF
--- a/src/main/java/com/ticket/captain/order/Order.java
+++ b/src/main/java/com/ticket/captain/order/Order.java
@@ -38,6 +38,7 @@ public class Order {
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
     private List<Ticket> tickets;
 
+    @Column(name = "status_id")
     private String statusCode;
 
     @CreatedDate


### PR DESCRIPTION
[TICKET-94] statusCode DB 'status_id'와 매핑하도록 @Column 추가

<br>

### 완료 조건

- [x] `Order Entity에 있는 statusCode @column 이용하여 'status_id'와 매핑`

<br> 

### 주안점

한게... 없네요..

<br>

## 연관 PR

 java-book-study/ticket-expeditionary-force#55 : DB 설정으로 인한 연관

<br>

## 연관 티켓

[TICKET-93](https://dolph.atlassian.net/browse/TICKET-93)
[TICKET-94](https://dolph.atlassian.net/browse/TICKET-94)

<br>

#### 레퍼런스

---

<br>

## 체크리스트

- [x] PR 제목은 유의미한가요?
- [x] 무엇을 변경했는지 충분히 설명하고 있나요?
- [ ] reference가 있다면 추가했나요?
- [x] 작업을 설명하는 Jira 티켓을 추가했나요?
- [ ] 작업 범위에 대해서 테스트를 작성하셨나요?
- [x] 팀원 두명을 Assign하고, Review Request에는 모든 팀원을 추가했나요?
- [ ] 새로운 기술을 사용했다면, 그 기술을 설명하고 있나요?
- [ ] 이해하기 어려운 비즈니스 로직에 관해서 부연 설명을 하고 있나요?
- [ ] 인프라 작업, 릴리즈 PR이라면, Review Skip 레이블을 추가했나요?

---


[TICKET-94]: https://dolph.atlassian.net/browse/TICKET-94