### PR TITLE
 [TICKET-103] fix: Scrap 이메일 오류 수정

### DIFF
--- a/src/main/java/com/ticket/captain/account/AccountService.java
+++ b/src/main/java/com/ticket/captain/account/AccountService.java
@@ -147,4 +147,8 @@ public class AccountService implements UserDetailsService {
     public void deleteById(Long accountId) {
         accountRepository.deleteById(accountId);
     }
+
+    public boolean existByEmail(String email){
+       return accountRepository.existsByEmail(email);
+    }
 }

--- a/src/main/java/com/ticket/captain/config/security/SecurityConfig.java
+++ b/src/main/java/com/ticket/captain/config/security/SecurityConfig.java
@@ -40,13 +40,12 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/api/comment/**").hasAnyRole("USER", "ADMIN", "MANAGER")
                 .antMatchers("/api/manager/**").hasAnyRole("ADMIN", "MANAGER")
                 .antMatchers("/api/ticket/**").hasAnyRole("ADMIN", "MANAGER", "USER")
+                .antMatchers("/api/scrap/**").hasAnyRole("USER", "ADMIN", "MANAGER")
                 .antMatchers("/api/appointment/**").hasAnyRole("ADMIN")
                 .anyRequest().permitAll()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwt),
                         UsernamePasswordAuthenticationFilter.class);
-
-        ;
     }
 
     @Override

--- a/src/main/java/com/ticket/captain/festival/Festival.java
+++ b/src/main/java/com/ticket/captain/festival/Festival.java
@@ -51,8 +51,8 @@ public class Festival extends BaseEntity{
     @Column(name = "category_id")
     private String festivalCategory;
 
-    @OneToOne(mappedBy = "festival")
-    private Scrap scrap;
+    @OneToMany(mappedBy = "festival", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Scrap> scraps;
 
     public static Festival createFestival(String title, String thumbnail, String content, LocalDateTime salesStartDate, LocalDateTime salesEndDate, String festivalCategory) {
         return Festival.builder()

--- a/src/main/java/com/ticket/captain/review/ReviewService.java
+++ b/src/main/java/com/ticket/captain/review/ReviewService.java
@@ -44,7 +44,7 @@ public class ReviewService {
         return Review.builder()
                 .title(reviewCreateDto.getTitle())
                 .contents(reviewCreateDto.getContents())
-                .writer(account.getName())
+                .writer(account.getNickname())
                 .commentCount(0)
                 .account(account)
                 .festival(festival)

--- a/src/main/java/com/ticket/captain/scrap/Scrap.java
+++ b/src/main/java/com/ticket/captain/scrap/Scrap.java
@@ -17,7 +17,7 @@ public class Scrap {
     @Id @GeneratedValue
     private Long id;
 
-    @OneToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "festival_id")
     private Festival festival;
 

--- a/src/main/java/com/ticket/captain/scrap/ScrapController.java
+++ b/src/main/java/com/ticket/captain/scrap/ScrapController.java
@@ -2,6 +2,7 @@ package com.ticket.captain.scrap;
 
 import com.ticket.captain.account.Account;
 import com.ticket.captain.account.CurrentUser;
+import com.ticket.captain.scrap.dto.ScrapDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.Link;
@@ -24,9 +25,9 @@ public class ScrapController {
     @RequestMapping(value = "{festivalId}", method = RequestMethod.POST)
     public ResponseEntity<?> createScrap(@CurrentUser Account account, @PathVariable Long festivalId){
 
-        Long scrapId = scrapService.createScrap(account, festivalId);
-        EntityModel<Long> scrapModel = EntityModel.of(scrapId).add(linkTo(ScrapController.class).slash(scrapId).withSelfRel());
-        scrapModel.add(Link.of("/docs/index.html#create-scrapId").withRel("profile"));
+        ScrapDto scrapDto = scrapService.createScrap(account, festivalId);
+        EntityModel<ScrapDto> scrapModel = EntityModel.of(scrapDto).add(linkTo(ScrapController.class).slash(scrapDto.getScrapId()).withSelfRel());
+        scrapModel.add(Link.of("/docs/index.html#get-scrapId").withRel("profile"));
 
         return ResponseEntity.ok(scrapModel);
     }

--- a/src/main/java/com/ticket/captain/scrap/ScrapController.java
+++ b/src/main/java/com/ticket/captain/scrap/ScrapController.java
@@ -5,6 +5,7 @@ import com.ticket.captain.account.CurrentUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.Link;
+import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,21 +16,22 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping(value = "/api/scrap/", produces = MediaTypes.HAL_JSON_VALUE)
 public class ScrapController {
 
     private final ScrapService scrapService;
 
-    @RequestMapping(value = "/scrap/{festivalId}", method = RequestMethod.POST)
+    @RequestMapping(value = "{festivalId}", method = RequestMethod.POST)
     public ResponseEntity<?> createScrap(@CurrentUser Account account, @PathVariable Long festivalId){
 
         Long scrapId = scrapService.createScrap(account, festivalId);
         EntityModel<Long> scrapModel = EntityModel.of(scrapId).add(linkTo(ScrapController.class).slash(scrapId).withSelfRel());
-        scrapModel.add(Link.of("/docs/index.html#get-scrapId").withRel("profile"));
+        scrapModel.add(Link.of("/docs/index.html#create-scrapId").withRel("profile"));
 
-        return ResponseEntity.ok(scrapId);
+        return ResponseEntity.ok(scrapModel);
     }
 
-    @RequestMapping(value = "/scrap/{scrapId}", method = RequestMethod.DELETE)
+    @RequestMapping(value = "{scrapId}", method = RequestMethod.DELETE)
     public ResponseEntity<?> deleteScrap(@CurrentUser Account account, @PathVariable Long scrapId){
 
         scrapService.deleteScrap(account, scrapId);

--- a/src/main/java/com/ticket/captain/scrap/ScrapService.java
+++ b/src/main/java/com/ticket/captain/scrap/ScrapService.java
@@ -4,6 +4,7 @@ import com.ticket.captain.account.Account;
 import com.ticket.captain.exception.NotFoundException;
 import com.ticket.captain.festival.Festival;
 import com.ticket.captain.festival.FestivalRepository;
+import com.ticket.captain.scrap.dto.ScrapDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,15 +16,13 @@ public class ScrapService {
 
     private final FestivalRepository festivalRepository;
 
-    public Long createScrap(Account account , Long festivalId){
+    public ScrapDto createScrap(Account account , Long festivalId){
 
         Festival festival = festivalRepository.findById(festivalId).orElseThrow(NotFoundException::new);
 
         Scrap scrap = new Scrap(account,festival);
 
-        Scrap save = scrapRepository.save(scrap);
-
-        return save.getId();
+        return ScrapDto.of(scrapRepository.save(scrap));
     }
 
     public void deleteScrap(Account account, Long scrapId) {

--- a/src/main/java/com/ticket/captain/scrap/dto/ScrapDto.java
+++ b/src/main/java/com/ticket/captain/scrap/dto/ScrapDto.java
@@ -1,0 +1,20 @@
+package com.ticket.captain.scrap.dto;
+
+import com.ticket.captain.scrap.Scrap;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@Builder
+public class ScrapDto {
+
+    private Long scrapId;
+
+    public static ScrapDto of(Scrap scrap) {
+
+        return ScrapDto.builder()
+                    .scrapId(scrap.getId())
+                    .build();
+    }
+}

--- a/src/test/java/com/ticket/captain/account/WithAccount.java
+++ b/src/test/java/com/ticket/captain/account/WithAccount.java
@@ -10,5 +10,9 @@ import java.lang.annotation.RetentionPolicy;
 @WithSecurityContext(factory = WithAccountSecurityContextFactory.class)
 public @interface WithAccount {
 
-    String value();
+    String email() default "testTicket@gmail.com";
+
+    String nickname() default "testTicket";
+
+    Role role() default Role.ROLE_USER;
 }

--- a/src/test/java/com/ticket/captain/account/WithAccountSecurityContextFactory.java
+++ b/src/test/java/com/ticket/captain/account/WithAccountSecurityContextFactory.java
@@ -26,6 +26,8 @@ public class WithAccountSecurityContextFactory implements WithSecurityContextFac
 
         Address address = new Address("seoul", "gangnam", "111");
 
+        AccountDto accountDto;
+
         AccountCreateDto accountCreateDto = AccountCreateDto.builder()
                 .email(nickname + "@naver.com")
                 .password("1q2w3e4r")
@@ -33,7 +35,13 @@ public class WithAccountSecurityContextFactory implements WithSecurityContextFac
                 .name("eunseong")
                 .address(address)
                 .build();
-        AccountDto accountDto = accountService.createAccount(accountCreateDto);
+
+        if(! accountService.existByEmail(accountCreateDto.getEmail()) ){
+            accountDto = accountService.createAccount(accountCreateDto);
+            accountService.roleAppoint(accountDto.getId(), Role.ROLE_USER);
+        }else{
+            accountDto = AccountDto.of(accountService.findByEmail(nickname + "@naver.com"));
+        }
 
         UserDetails principal = accountService.loadUserByUsername(accountDto.getEmail());
         Authentication authentication = new UsernamePasswordAuthenticationToken(principal, "", Collections.singleton(new SimpleGrantedAuthority(Role.ROLE_USER.name())));

--- a/src/test/java/com/ticket/captain/review/ReviewRestControllerTest.java
+++ b/src/test/java/com/ticket/captain/review/ReviewRestControllerTest.java
@@ -59,7 +59,6 @@ public class ReviewRestControllerTest {
 
     private final String REVIEW_API_ADDRESS = "/api/review/";
 
-
     @BeforeEach
     void setUp() {
         FestivalCreateDto festivalCreateDto = FestivalCreateDto.builder()
@@ -76,7 +75,7 @@ public class ReviewRestControllerTest {
 
     @Test
     @DisplayName("리뷰 작성")
-    @WithAccount("eunseong")
+    @WithAccount
     public void reviewWrite() throws Exception {
         ReviewCreateDto createDto = reviewCreateDtoSample();
 
@@ -112,7 +111,7 @@ public class ReviewRestControllerTest {
 
     @Test
     @DisplayName("리뷰 작성 실패")
-    @WithAccount("eunseong")
+    @WithAccount
     public void reviewWriteFail() throws Exception{
         ReviewCreateDto createDto = ReviewCreateDto.builder()
                 .title("title")
@@ -138,7 +137,7 @@ public class ReviewRestControllerTest {
 
     @Test
     @DisplayName("리뷰 조회")
-    @WithAccount("eunseong")
+    @WithAccount(email = "eunseong@naver.com")
     public  void reviewDetail() throws Exception {
         ReviewDto reviewDto = reviewCreate("eunseong@naver.com");
 
@@ -169,7 +168,7 @@ public class ReviewRestControllerTest {
 
     @Test
     @DisplayName("리뷰 수정")
-    @WithAccount("eunseong")
+    @WithAccount(email = "eunseong@naver.com")
     public void reviewUpdate() throws Exception {
         ReviewDto reviewDto = reviewCreate("eunseong@naver.com");
 
@@ -213,7 +212,7 @@ public class ReviewRestControllerTest {
 
     @Test
     @DisplayName("리뷰 수정실패")
-    @WithAccount("eunseong")
+    @WithAccount
     public void reviewUpdateFail() throws Exception {
         ReviewDto reviewDto = reviewCreate("oceana57@naver.com");
 
@@ -247,7 +246,7 @@ public class ReviewRestControllerTest {
 
     @Test
     @DisplayName("리뷰 삭제")
-    @WithAccount("eunseong")
+    @WithAccount(email = "eunseong@naver.com")
     public void reviewDelete() throws Exception{
         ReviewDto reviewDto = reviewCreate("eunseong@naver.com");
 
@@ -260,7 +259,7 @@ public class ReviewRestControllerTest {
 
     @Test
     @DisplayName("리뷰 삭제실패")
-    @WithAccount("eunseong")
+    @WithAccount
     public void reviewDeleteFail() throws Exception{
         ReviewDto reviewDto = reviewCreate("oceana57@naver.com");
 

--- a/src/test/java/com/ticket/captain/scrap/ScrapControllerTest.java
+++ b/src/test/java/com/ticket/captain/scrap/ScrapControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -39,6 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @AutoConfigureRestDocs
 @Slf4j
+@Transactional
 public class ScrapControllerTest {
 
     @Autowired
@@ -72,7 +74,7 @@ public class ScrapControllerTest {
 
     }
 
-    @WithAccount(value = testEmail)
+    @WithAccount
     @Test
     public void createScrapTest() throws Exception {
         //given
@@ -93,7 +95,7 @@ public class ScrapControllerTest {
                 ));
     }
 
-    @WithAccount(value = testEmail)
+    @WithAccount
     @Test
     public void deleteScrapTest() throws Exception {
 

--- a/src/test/java/com/ticket/captain/scrap/ScrapControllerTest.java
+++ b/src/test/java/com/ticket/captain/scrap/ScrapControllerTest.java
@@ -7,7 +7,7 @@ import com.ticket.captain.enumType.FestivalCategory;
 import com.ticket.captain.festival.FestivalService;
 import com.ticket.captain.festival.dto.FestivalCreateDto;
 import com.ticket.captain.festival.dto.FestivalDto;
-import com.ticket.captain.security.Jwt;
+import com.ticket.captain.scrap.dto.ScrapDto;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -53,11 +53,6 @@ public class ScrapControllerTest {
     @Autowired
     private AccountRepository accountRepository;
 
-    @Autowired
-    private Jwt jwt;
-
-    private String jwtToken;
-
     private Long festivalId;
 
     private final static String testEmail = "testEmail";
@@ -80,7 +75,6 @@ public class ScrapControllerTest {
     @WithAccount(value = testEmail)
     @Test
     public void createScrapTest() throws Exception {
-
         //given
         mockMvc.perform(post("/api/scrap/{festivalId}", festivalId)
                 .contentType(MediaType.APPLICATION_JSON))
@@ -104,9 +98,9 @@ public class ScrapControllerTest {
     public void deleteScrapTest() throws Exception {
 
         Account account = accountRepository.findByEmail(testEmail);
-        Long scrapId = scrapService.createScrap(account, festivalId);
+        ScrapDto scrapDto = scrapService.createScrap(account, festivalId);
 
-        mockMvc.perform(delete("/api/scrap/{scrapId}", scrapId))
+        mockMvc.perform(delete("/api/scrap/{scrapId}", scrapDto.getScrapId()))
                 .andDo(print())
                 .andExpect(status().isOk());
 


### PR DESCRIPTION
### 완료 조건

- [ ] `이메일 연동 시 에러 발생`
- [ ] `Rest Docs의 responseField에서 entity를 읽지 못한 점`


### 주안점
WithAccountSecurityContextFactory 이 부분이 현성님과 Conflict가 나지 않을까 생각합니다.


## 연관 PR

- java-book-study/ticket-expeditionary-force #67 

## 연관 티켓

TIEKCT-98

#### 레퍼런스

- 갓민현님의 Slack Comment

